### PR TITLE
Refactor: Add two image destination filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.5.0
-* Feat: Added translation languages for `Japanese`,`Indonesian`,`Danish`, `Turkish`, `Polish`, `Dutch`, `Brazil` and `Portuguese`.
+* Feat: Add translation languages for `Japanese`,`Indonesian`,`Danish`, `Turkish`, `Polish`, `Dutch`, `Brazil` and `Portuguese`.
 * Feat: Add new custom filter `icfw_image_abs_destination` and `icfw_image_rel_destination`.
 
 ## 1.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.5.0
 * Feat: Added translation languages for `Japanese`,`Indonesian`,`Danish`, `Turkish`, `Polish`, `Dutch`, `Brazil` and `Portuguese`.
+* Feat: Add new custom filter `icfw_image_abs_destination` and `icfw_image_rel_destination`.
 
 ## 1.4.1
 * Specify `wordpress-plugin` as Composer package type.

--- a/README.md
+++ b/README.md
@@ -22,23 +22,21 @@ You may not realize it, but __imagery is a large part of it__. This plugin helps
 
 ### `icfw_image_abs_destination` && `icfw_image_rel_destination`
 
-This custom hook (filter) provides the ability for users to rename the image to a preferred file naming convention of their choice.For e.g
-you could do:
+This custom hook (filter) provides the ability for users to rename the image to a preferred file naming convention of their choice. For e.g you could append the timestamp to the name of the file like so:
 
 ```php
 add_filter( 'icfw_image_abs_destination', 'custom_abs_destination', 10, 3 );
 add_filter( 'icfw_image_rel_destination', 'custom_rel_destination', 10, 3 );
 
 public function custom_abs_destination( $abs_dest, $abs_source, $ext ): void {
-  $convention = 'convention_name';
-  return str_replace( '.webp', sprintf( '-%d.webp', $convention ), $abs_dest );
+  $icfw_timestamp = time();
+  return str_replace( '.webp', sprintf( '-%d.webp', $icfw_timestamp ), $abs_dest );
 }
 
 public function custom_rel_destination( $rel_dest, $rel_source, $ext ): void {
-  $convention = 'convention_name';
-  return str_replace( '.webp', sprintf( '-%d.webp', $convention ), $rel_dest );
+  $icfw_timestamp = time();
+  return str_replace( '.webp', sprintf( '-%d.webp', $icfw_timestamp ), $rel_dest );
 }
-
 ```
 
 <br/>

--- a/README.md
+++ b/README.md
@@ -20,6 +20,29 @@ You may not realize it, but __imagery is a large part of it__. This plugin helps
 
 ### Hooks
 
+### `icfw_image_abs_destination` && `icfw_image_rel_destination`
+
+This custom hook (filter) provides the ability for users to rename the image to a preferred file naming convention of their choice.For e.g
+you could do:
+
+```php
+add_filter( 'icfw_image_abs_destination', 'custom_abs_destination', 10, 3 );
+add_filter( 'icfw_image_rel_destination', 'custom_rel_destination', 10, 3 );
+
+public function custom_abs_destination( $abs_dest, $abs_source, $ext ): void {
+  $convention = 'convention_name';
+  return str_replace( '.webp', sprintf( '-%d.webp', $convention ), $abs_dest );
+}
+
+public function custom_rel_destination( $rel_dest, $rel_source, $ext ): void {
+  $convention = 'convention_name';
+  return str_replace( '.webp', sprintf( '-%d.webp', $convention ), $rel_dest );
+}
+
+```
+
+<br/>
+
 #### `icfw_options`
 
 This custom hook (filter) provides the ability to add custom options for your image conversions to WebP. For e.g. to perform a 50% quality, image conversion using the Imagick extension, you could do:

--- a/inc/Core/Converter.php
+++ b/inc/Core/Converter.php
@@ -179,8 +179,11 @@ class Converter {
 	protected function set_image_destination(): void {
 		$image_extension = '.' . pathinfo( $this->service->source['url'], PATHINFO_EXTENSION );
 
+		// Get relative source url.
+		$rel_source_url = $this->service->source['url'] ?? '';
+
 		$image_abs_dest = str_replace( $image_extension, '.webp', $this->abs_source );
-		$image_rel_dest = str_replace( $image_extension, '.webp', $this->service->source['url'] );
+		$image_rel_dest = str_replace( $image_extension, '.webp', $rel_source_url );
 
 		/**
 		 * Filter Image absolute destination.
@@ -206,7 +209,7 @@ class Converter {
 		 *
 		 * @return string
 		 */
-		$this->rel_dest = apply_filters( 'icfw_image_rel_destination', $image_rel_dest, $this->service->source['url'], $image_extension );
+		$this->rel_dest = apply_filters( 'icfw_image_rel_destination', $image_rel_dest, $rel_source_url, $image_extension );
 	}
 
 

--- a/inc/Core/Converter.php
+++ b/inc/Core/Converter.php
@@ -189,8 +189,8 @@ class Converter {
 		 * Filter Image absolute destination.
 		 *
 		 * This filter provides a way for users to rename
-		 * the image to a preferred file naming convention
-		 * of their choice.
+		 * the absolute source image of the webp to a preferred
+		 * file naming convention of their choice.
 		 *
 		 * @since 1.5.0
 		 *
@@ -202,8 +202,8 @@ class Converter {
 		 * Filter Image relative destination.
 		 *
 		 * This filter provides a way for users to rename
-		 * the image to a preferred file naming convention
-		 * of their choice.
+		 * the destination image of the webp to a preferred
+		 * file naming convention of their choice.
 		 *
 		 * @since 1.5.0
 		 *

--- a/inc/Core/Converter.php
+++ b/inc/Core/Converter.php
@@ -194,6 +194,18 @@ class Converter {
 		 * @return string
 		 */
 		$this->abs_dest = apply_filters( 'icfw_image_abs_destination', $image_abs_dest, $this->abs_source, $image_extension );
+
+		/**
+		 * Filter Image relative destination.
+		 *
+		 * This filter provides a way for users to rename
+		 * the image to a preferred file naming convention
+		 * of their choice.
+		 *
+		 * @since 1.5.0
+		 *
+		 * @return string
+		 */
 		$this->rel_dest = apply_filters( 'icfw_image_rel_destination', $image_rel_dest, $this->service->source['url'], $image_extension );
 	}
 

--- a/inc/Core/Converter.php
+++ b/inc/Core/Converter.php
@@ -179,9 +179,24 @@ class Converter {
 	protected function set_image_destination(): void {
 		$image_extension = '.' . pathinfo( $this->service->source['url'], PATHINFO_EXTENSION );
 
-		$this->abs_dest = str_replace( $image_extension, '.webp', $this->abs_source );
-		$this->rel_dest = str_replace( $image_extension, '.webp', $this->service->source['url'] );
+		$image_abs_dest = str_replace( $image_extension, '.webp', $this->abs_source );
+		$image_rel_dest = str_replace( $image_extension, '.webp', $this->service->source['url'] );
+
+		/**
+		 * Filter Image absolute destination.
+		 *
+		 * This filter provides a way for users to rename
+		 * the image to a preferred file naming convention
+		 * of their choice.
+		 *
+		 * @since 1.5.0
+		 *
+		 * @return string
+		 */
+		$this->abs_dest = apply_filters( 'icfw_image_abs_destination', $image_abs_dest, $this->abs_source, $image_extension );
+		$this->rel_dest = apply_filters( 'icfw_image_rel_destination', $image_rel_dest, $this->service->source['url'], $image_extension );
 	}
+
 
 	/**
 	 * Get Options.

--- a/readme.txt
+++ b/readme.txt
@@ -72,7 +72,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 = 1.5.0 =
 * Feat: Added translation languages for `Japanese`,`Indonesian`,`Danish`, `Turkish`, `Polish`, `Dutch`, `Brazil` and `Portuguese`.
-
+* Feat: Add new custom filter `icfw_image_abs_destination` and `icfw_image_rel_destination`.
 = 1.4.1 =
 * Specify `wordpress-plugin` as Composer package type.
 * Tested up to WP 6.9.

--- a/readme.txt
+++ b/readme.txt
@@ -71,7 +71,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 == Changelog ==
 
 = 1.5.0 =
-* Feat: Added translation languages for `Japanese`,`Indonesian`,`Danish`, `Turkish`, `Polish`, `Dutch`, `Brazil` and `Portuguese`.
+* Feat: Add translation languages for `Japanese`,`Indonesian`,`Danish`, `Turkish`, `Polish`, `Dutch`, `Brazil` and `Portuguese`.
 * Feat: Add new custom filter `icfw_image_abs_destination` and `icfw_image_rel_destination`.
 
 = 1.4.1 =

--- a/readme.txt
+++ b/readme.txt
@@ -73,6 +73,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 = 1.5.0 =
 * Feat: Added translation languages for `Japanese`,`Indonesian`,`Danish`, `Turkish`, `Polish`, `Dutch`, `Brazil` and `Portuguese`.
 * Feat: Add new custom filter `icfw_image_abs_destination` and `icfw_image_rel_destination`.
+
 = 1.4.1 =
 * Specify `wordpress-plugin` as Composer package type.
 * Tested up to WP 6.9.

--- a/tests/Core/ConverterTest.php
+++ b/tests/Core/ConverterTest.php
@@ -237,6 +237,20 @@ class ConverterTest extends TestCase {
 		$converter->shouldAllowMockingProtectedMethods();
 		$converter->service = $service;
 
+		WP_Mock::expectFilter(
+			'icfw_image_abs_destination',
+			'/var/www/html/wp-content/uploads/2024/01/sample.webp',
+			'/var/www/html/wp-content/uploads/2024/01/sample.jpeg',
+			'.jpeg'
+		);
+
+		WP_Mock::expectFilter(
+			'icfw_image_rel_destination',
+			'https://example.com/wp-content/uploads/2024/01/sample.webp',
+			'https://example.com/wp-content/uploads/2024/01/sample.jpeg',
+			'.jpeg'
+		);
+
 		$converter->service->source = [
 			'id'  => 1,
 			'url' => 'https://example.com/wp-content/uploads/2024/01/sample.jpeg',


### PR DESCRIPTION
This PR resolves [WP-182](https://appworld.atlassian.net/browse/WP-182)

## Description / Background Context

Based on a recent request by one of the plugin users, we need to add filters that would provide users the ability to modify the destination file paths for the newly generated webps. 

```php
$icfw_timestamp = time();

add_filter( 'icfw_image_abs_destination', function( $abs_dest, $abs_source, $ext ) use ( $icfw_timestamp ) {
    return str_replace( '.webp', sprintf( '-%d.webp', $icfw_timestamp ), $abs_dest );
}, 10, 3 );

add_filter( 'icfw_image_rel_destination', function( $rel_dest, $rel_source, $ext ) use ( $icfw_timestamp ) {
    return str_replace( '.webp', sprintf( '-%d.webp', $icfw_timestamp ), $rel_dest );
}, 10, 3 );
```

## Testing Instructions

- Pull PR to local
- Proceed to uploading an image to a post and observe the name of the file (Like in the before picture below)  in the media directory afterwards.
- Then add the above code to the plugin file `image-converter-webp.php`.
- Now upload a new image and observe that the name of the file (Like in the after picture below) in the media directory.

## Screenshots / Screencast

**BEFORE**

---

<img width="424" height="213" alt="Screenshot 2026-03-16 165142" src="https://github.com/user-attachments/assets/88f69c6a-abb2-436d-a2ba-eeb798efb1cc" />

---

**AFTER**

---

<img width="404" height="222" alt="Screenshot 2026-03-16 165032" src="https://github.com/user-attachments/assets/63052001-02a2-4db1-9990-c8f8f556537b" />

