### PR TITLE
Feat: Add `More Plugins` Options page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.0
+* Feat: Add `More Plugins` options page.
+
 ## 1.5.2
 * Tested up to WP 7.0.
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     }
   ],
   "require": {
-    "rosell-dk/webp-convert": "^2.9"
+    "rosell-dk/webp-convert": "^2.9",
+    "badasswp/pluginate": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.6",

--- a/inc/Services/Admin.php
+++ b/inc/Services/Admin.php
@@ -19,6 +19,10 @@ use Pluginate\Admin as Pluginate;
 
 class Admin extends Service implements Kernel {
 	/**
+	 * Pluginate instance.
+	 *
+	 * @since 1.6.0
+	 *
 	 * @var Pluginate
 	 */
 	public Pluginate $pluginate;

--- a/inc/Services/Admin.php
+++ b/inc/Services/Admin.php
@@ -15,7 +15,23 @@ use ImageConverterWebP\Admin\Options;
 use ImageConverterWebP\Abstracts\Service;
 use ImageConverterWebP\Interfaces\Kernel;
 
+use Pluginate\Admin as Pluginate;
+
 class Admin extends Service implements Kernel {
+	/**
+	 * @var Pluginate
+	 */
+	public Pluginate $pluginate;
+
+	/**
+	 * Admin constructor.
+	 *
+	 * @since 1.6.0
+	 */
+	public function __construct() {
+		$this->pluginate = new Pluginate( 'image-converter-webp' );
+	}
+
 	/**
 	 * Bind to WP.
 	 *
@@ -27,6 +43,7 @@ class Admin extends Service implements Kernel {
 		add_action( 'admin_init', [ $this, 'register_options_init' ] );
 		add_action( 'admin_menu', [ $this, 'register_options_menu' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'register_options_styles' ] );
+		add_action( 'admin_init', [ $this->pluginate, 'init' ] );
 	}
 
 	/**
@@ -49,6 +66,15 @@ class Admin extends Service implements Kernel {
 			[ $this, 'register_options_page' ],
 			'dashicons-format-image',
 			100
+		);
+
+		add_submenu_page(
+			Options::get_page_slug(),
+			__( 'More Plugins', 'image-converter-webp' ),
+			__( 'More Plugins', 'image-converter-webp' ),
+			'manage_options',
+			sprintf( '%s-more-plugins', Options::get_page_slug() ),
+			[ $this, 'register_more_plugins' ]
 		);
 	}
 
@@ -73,6 +99,35 @@ class Admin extends Service implements Kernel {
 			array_map(
 				'__',
 				( new Form( Options::$form ) )->get_options()
+			)
+		);
+	}
+
+	/**
+	 * Register More Plugins.
+	 *
+	 * This controls the display of the
+	 * "More Plugins" submenu page.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @return void
+	 */
+	public function register_more_plugins(): void {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		vprintf(
+			'<section class="wrap">
+				<h1>%s</h1>
+				<p>%s</p>
+				%s
+			</section>',
+			array_map(
+				'__',
+				[
+					'More Plugins',
+					'Check out some other amazing plugin of ours...',
+					$this->pluginate->get_more_plugins(),
+				]
 			)
 		);
 	}
@@ -137,7 +192,7 @@ class Admin extends Service implements Kernel {
 		$screen = get_current_screen();
 
 		// Bail out, if not plugin Admin page.
-		if ( ! is_object( $screen ) || 'toplevel_page_image-converter-webp' !== $screen->id ) {
+		if ( ! is_object( $screen ) || ! str_contains( $screen->id, Options::get_page_slug() ) ) {
 			return;
 		}
 

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -30,6 +30,7 @@ use ImageConverterWebP\Services\PageLoad;
  * @covers \ImageConverterWebP\Services\Main::register
  * @covers \ImageConverterWebP\Services\MetaData::register
  * @covers \ImageConverterWebP\Services\PageLoad::register
+ * @covers \ImageConverterWebP\Services\Admin::__construct
  */
 class PluginTest extends TestCase {
 	public array $services;

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -87,6 +87,16 @@ class PluginTest extends TestCase {
 			]
 		);
 
+		$admin = Service::$services['ImageConverterWebP\Services\Admin'];
+
+		WP_Mock::expectActionAdded(
+			'admin_init',
+			[
+				$admin->pluginate,
+				'init',
+			]
+		);
+
 		WP_Mock::expectActionAdded(
 			'icfw_convert',
 			[

--- a/tests/Services/AdminTest.php
+++ b/tests/Services/AdminTest.php
@@ -39,6 +39,7 @@ class AdminTest extends WPMockTestCase {
 		WP_Mock::expectActionAdded( 'admin_init', [ $this->admin, 'register_options_init' ] );
 		WP_Mock::expectActionAdded( 'admin_menu', [ $this->admin, 'register_options_menu' ] );
 		WP_Mock::expectActionAdded( 'admin_enqueue_scripts', [ $this->admin, 'register_options_styles' ] );
+		WP_Mock::expectActionAdded( 'admin_init', [ $this->admin->pluginate, 'init' ] );
 
 		$this->admin->register();
 
@@ -56,6 +57,18 @@ class AdminTest extends WPMockTestCase {
 				[ $this->admin, 'register_options_page' ],
 				'dashicons-format-image',
 				100
+			)
+			->andReturn( null );
+
+		WP_Mock::userFunction( 'add_submenu_page' )
+			->once()
+			->with(
+				'image-converter-webp',
+				__( 'More Plugins', 'image-converter-webp' ),
+				__( 'More Plugins', 'image-converter-webp' ),
+				'manage_options',
+				sprintf( '%s-more-plugins', 'image-converter-webp' ),
+				[ $this->admin, 'register_more_plugins' ]
 			)
 			->andReturn( null );
 
@@ -202,7 +215,7 @@ class AdminTest extends WPMockTestCase {
 	public function test_register_options_styles_bails_out_if_screen_is_not_plugin_page() {
 		$screen = Mockery::mock( WP_Screen::class )->makePartial();
 		$screen->shouldAllowMockingProtectedMethods();
-		$screen->id = 'media_page_image-converter-webp';
+		$screen->id = 'media_page_another-plugin';
 
 		WP_Mock::userFunction( 'get_current_screen' )
 			->andReturn( $screen );


### PR DESCRIPTION
This PR resolves [WP-188](https://appworld.atlassian.net/browse/WP-188).

## Description / Background Context

This PR introduces a new More Plugins options page via the Pluginate repo.

## Testing Instructions

- Pull PR to local.
- Run `composer update` to pull in the `Pluginate` package.
- Proceed to the **More Plugins** page under the **Image Converter for WebP** menu.
- Observe that everything still works correctly as expected and you can install and activate a plugin from same.

## Screenshots / Screencast

<img width="1728" height="896" alt="Screenshot 2026-06-05 at 14 23 40" src="https://github.com/user-attachments/assets/8ce1f3e0-edb1-4bb3-913e-757a2fb23f91" />
